### PR TITLE
Fix checksum edge case.

### DIFF
--- a/tcpStack/FCS.cpp
+++ b/tcpStack/FCS.cpp
@@ -49,12 +49,10 @@ uint32_t FCS::ChecksumAdd(const uint8_t* buffer, int length, uint32_t checksum)
 
 uint16_t FCS::ChecksumComplete(uint32_t checksum)
 {
-    uint16_t sum;
-    sum = (checksum & 0xFFFF);
-    sum += (checksum >> 16);
-    sum = ~sum;
+    checksum = (checksum & 0xFFFF) + (checksum >> 16);
+    checksum = (checksum & 0xFFFF) + (checksum >> 16);
 
-    return sum;
+    return (uint16_t)~checksum;
 }
 
 uint16_t FCS::Checksum(const uint8_t* buffer, int length)


### PR DESCRIPTION
Hey there,

I think that I found a relatively rare edge case, in which a wrong checksum is calculated. The following test case reports 0xffff when verifying a checksum over data that's designed to lead to an instance of this edge case. One would expect 0x0000 when running the checksum algorithm over correcly checksummed data.

```
#include <cstdint>                                                               
#include <iostream>                                                              
                                                                                 
#include <FCS.hpp>                                                               
                                                                                 
int main(int argc, char *argv[])                                                 
{                                                                                
    (void)argc;                                                                  
    (void)argv;                                                                  
                                                                                 
    // data[0] and data[1] will receive the checksum                             
    uint8_t data[10] = {                                                         
        0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01               
    };                                                                           
                                                                                 
    // for checksum calculation, data[0] and data[1] are zero                    
    uint16_t checksum = FCS::Checksum(data, sizeof data);                        
                                                                                 
    // populate data[0] and data[1] with the checksum                            
    data[0] = (uint8_t)(checksum >> 8);                                          
    data[1] = (uint8_t)checksum;                                                 
                                                                                 
    // verify the checksum - should return 0x0000 for a valid checksum           
    uint16_t verify = FCS::Checksum(data, sizeof data);                          
                                                                                 
    std::cout << std::hex << "0x" << verify << std::endl;                        
                                                                                 
    return 0;                                                                    
}                                                                                
```

The edge case arises when there's still a carry-out after folding the upper 16 bits into the lower 16 bits once. In order to be sure to catch this carry-out, we need to fold again.

Folding twice is enough. After the second time we can be sure that there isn't any carry-out:

  * The first fold adds two 16-bit values: the upper 16 bits of `checksum` and the lower 16 bits of `checksum`.
  * The maximal sum of two 16-bit values is 0xffff + 0xffff = 0x1fffe.
  * Folding a second time takes care even of this maximal sum without producing a new carry-out: it turns 0x1fffe into 0xffff.
  * Hence two folds are enough.

A back-of-the-envelope calculation regarding the impact of this issue:

  * Let's assume a TCP download in steady state, i.e., with roughly 1500-byte packets.
  * When adding together the 750 16-bit words of such a packet, one would expect a carry-out every 2 words. This would be about 750 / 2 = 375 carry-outs, i.e., on average the upper 16 bits of `checksum` would be 375.
  * For the edge case to arise, i.e., for the first fold to produce a carry-out, the lower 16 bits of `checksum` would then have to be at least 65536 - 375 = 65161. When the lower 16 bits are < 65161, we're OK.
  * So, we're OK in 65161 out of 65536 cases = ~99.4% of cases. So this is a really rare thing. And shorter packets make it even less likely to happen, as we'd expect fewer than 375 carry-outs.
